### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/symbtrdataextractor/GraphOperations.py
+++ b/symbtrdataextractor/GraphOperations.py
@@ -20,8 +20,7 @@ class GraphOperations(object):
     @staticmethod
     def get_dist_matrix(stream1, stream2=None, metric='norm_levenshtein'):
         if metric not in GraphOperations._metrics:
-            raise ValueError("The distance metric can be: %s"
-                             % ', '.join(GraphOperations._metrics))
+            raise ValueError("The distance metric can be: {0!s}".format(', '.join(GraphOperations._metrics)))
         dist_metric = getattr(GraphOperations, metric)
 
         if stream2 is None:  # return self distance matrix

--- a/symbtrdataextractor/OffsetProcessor.py
+++ b/symbtrdataextractor/OffsetProcessor.py
@@ -34,8 +34,7 @@ class OffsetProcessor(object):
             if self.print_warnings:
                 warn_str = ', '.join(str(e) for e in noninteger_measure_starts)
 
-                warnings.warn(u"Some measures are skipped by the offsets: %s"
-                              % warn_str)
+                warnings.warn(u"Some measures are skipped by the offsets: {0!s}".format(warn_str))
 
         return is_measure_start_valid
 

--- a/symbtrdataextractor/SectionExtractor.py
+++ b/symbtrdataextractor/SectionExtractor.py
@@ -169,8 +169,7 @@ class SectionExtractor(object):
         if next_lyrics_measure_offset == floor(
                 score['offset'][prev_closest_end_ind]):
             if self.print_warnings:
-                warnings.warn(u'%s: %s and %s are in the same measure!'
-                              % (str(next_lyrics_measure_offset),
+                warnings.warn(u'{0!s}: {1!s} and {2!s} are in the same measure!'.format(str(next_lyrics_measure_offset),
                                  score['lyrics'][prev_closest_end_ind],
                                  score['lyrics'][next_lyrics_start_ind]))
             return next_lyrics_measure_offset
@@ -207,8 +206,7 @@ class SectionExtractor(object):
         # treat some of these are warning; they'll be made stricter later
         if not sections:  # check section presence
             if self.print_warnings:
-                warnings.warn(u"%s, Missing section info in lyrics."
-                              % symbtrname)
+                warnings.warn(u"{0!s}, Missing section info in lyrics.".format(symbtrname))
             valid_bool = True  # nothing to validate
         else:  # check section continuity
             section_continuity_bool = self._validate_section_continuity(
@@ -234,8 +232,7 @@ class SectionExtractor(object):
         section_bound_bool = True
         for s in sections:
             if s['start_note'] > s['end_note']:
-                warnings.warn(u'%s, %s -> %s, %s ends before it starts: %s'
-                              % (symbtrname, str(s['start_note']),
+                warnings.warn(u'{0!s}, {1!s} -> {2!s}, {3!s} ends before it starts: {4!s}'.format(symbtrname, str(s['start_note']),
                                  str(s['end_note']), s['slug'],
                                  str(score['offset'][s['start_note']])))
                 section_bound_bool = False
@@ -263,8 +260,7 @@ class SectionExtractor(object):
             for label in all_labels:
                 # invalid lyrics end
                 if (label + ' ') == ll or (label + '  ') == ll:
-                    warnings.warn(u'%s, %s: Extra space in %s'
-                                  % (symbtrname, str(i), ll))
+                    warnings.warn(u'{0!s}, {1!s}: Extra space in {2!s}'.format(symbtrname, str(i), ll))
                     no_space_bool = False
 
         return no_space_bool
@@ -278,8 +274,7 @@ class SectionExtractor(object):
         for s, e in zip(start_note_idx, ends):
             if not s - e == 1:
                 if self.print_warnings:
-                    warnings.warn(u'%s, %s -> %s, Gap between the sections'
-                                  % (symbtrname, str(e), str(s)))
+                    warnings.warn(u'{0!s}, {1!s} -> {2!s}, Gap between the sections'.format(symbtrname, str(e), str(s)))
                     section_continuity_bool = False
 
         return section_continuity_bool

--- a/symbtrdataextractor/StructureLabeler.py
+++ b/symbtrdataextractor/StructureLabeler.py
@@ -151,7 +151,7 @@ class StructureLabeler(object):
             chk_strm = ([stream[i] for i, x in enumerate(labels)
                          if x == lbl])
             assert all(strm == cl for cl in chk_strm), \
-                'Mismatch in %s label: %s' % (name, lbl)
+                'Mismatch in {0!s} label: {1!s}'.format(name, lbl)
 
     @staticmethod
     def _semiotize(cliques):

--- a/symbtrdataextractor/metadata/MBMetadata.py
+++ b/symbtrdataextractor/metadata/MBMetadata.py
@@ -90,6 +90,5 @@ class MBMetadata(object):
         if 'mb_tag' in score_attrib.keys():  # recording
             if not score_attrib['mb_tag'] in attrib_dict['mb_tag']:
                 is_attribute_valid = False
-                warnings.warn(u'%s, %s: The MusicBrainz tag does not match.'
-                              % (scorename, score_attrib['mb_tag']))
+                warnings.warn(u'{0!s}, {1!s}: The MusicBrainz tag does not match.'.format(scorename, score_attrib['mb_tag']))
         return is_attribute_valid

--- a/symbtrdataextractor/metadata/MetadataExtractor.py
+++ b/symbtrdataextractor/metadata/MetadataExtractor.py
@@ -100,7 +100,8 @@ class MetadataExtractor(object):
     def _validate_slug(attrib_dict, score_attrib, scorename):
         if 'symbtr_slug' in score_attrib.keys():
             if not score_attrib['symbtr_slug'] == attrib_dict['symbtr_slug']:
-                warnings.warn(u'{0!s}, {1!s}: The slug does not match.'.format(scorename, score_attrib['symbtr_slug']))
+                warnings.warn(u'{0!s}, {1!s}: The slug does not match.'.
+                              format(scorename, score_attrib['symbtr_slug']))
                 return False
 
         return True
@@ -127,8 +128,9 @@ class MetadataExtractor(object):
                                 MetadataExtractor._compare_accidentals(k1, k2))
 
         if not is_key_sig_valid:
-            warnings.warn(u'{0!s}: Key signature is different! {1!s} -> {2!s}'.format(symbtr_name, ' '.join(key_signature),
-                             ' '.join(key_sig_makam)))
+            warnings.warn(u'{0!s}: Key signature is different! {1!s} -> {2!s}'.
+                          format(symbtr_name, ' '.join(key_signature),
+                                 ' '.join(key_sig_makam)))
 
         return is_key_sig_valid
 

--- a/symbtrdataextractor/metadata/MetadataExtractor.py
+++ b/symbtrdataextractor/metadata/MetadataExtractor.py
@@ -100,8 +100,7 @@ class MetadataExtractor(object):
     def _validate_slug(attrib_dict, score_attrib, scorename):
         if 'symbtr_slug' in score_attrib.keys():
             if not score_attrib['symbtr_slug'] == attrib_dict['symbtr_slug']:
-                warnings.warn(u'%s, %s: The slug does not match.'
-                              % (scorename, score_attrib['symbtr_slug']))
+                warnings.warn(u'{0!s}, {1!s}: The slug does not match.'.format(scorename, score_attrib['symbtr_slug']))
                 return False
 
         return True
@@ -128,8 +127,7 @@ class MetadataExtractor(object):
                                 MetadataExtractor._compare_accidentals(k1, k2))
 
         if not is_key_sig_valid:
-            warnings.warn(u'%s: Key signature is different! %s -> %s'
-                          % (symbtr_name, ' '.join(key_signature),
+            warnings.warn(u'{0!s}: Key signature is different! {1!s} -> {2!s}'.format(symbtr_name, ' '.join(key_signature),
                              ' '.join(key_sig_makam)))
 
         return is_key_sig_valid

--- a/symbtrdataextractor/metadata/Mu2Metadata.py
+++ b/symbtrdataextractor/metadata/Mu2Metadata.py
@@ -13,8 +13,7 @@ class Mu2Metadata(object):
 
                 if not mu2_name:  # no matching variant
                     is_attr_valid = False
-                    warnings.warn(u'%s, %s: The Mu2 attribute does not match.'
-                                  % (scorename, score_attrib['mu2_name']))
+                    warnings.warn(u'{0!s}, {1!s}: The Mu2 attribute does not match.'.format(scorename, score_attrib['mu2_name']))
 
             except KeyError:  # makam, form
                 is_attr_valid = Mu2Metadata._validate_mu2_makam_form(
@@ -26,8 +25,7 @@ class Mu2Metadata(object):
     def _validate_mu2_makam_form(score_attrib, attrib_dict, scorename):
         mu2_name = attrib_dict['mu2_name']
         if not score_attrib['mu2_name'] == mu2_name:
-            warnings.warn(u'%s, %s: The Mu2 attribute does not match.'
-                          % (scorename, score_attrib['mu2_name']))
+            warnings.warn(u'{0!s}, {1!s}: The Mu2 attribute does not match.'.format(scorename, score_attrib['mu2_name']))
             return False
 
         return True

--- a/symbtrdataextractor/reader/Mu2Reader.py
+++ b/symbtrdataextractor/reader/Mu2Reader.py
@@ -102,7 +102,7 @@ class Mu2Reader(SymbTrReader):
                 elif code == 63:
                     header['notation'] = row[7]
                 elif code in range(50, 64):
-                    warnings.warn(u'Unparsed code: %s' % ' '.join(row))
+                    warnings.warn(u'Unparsed code: {0!s}'.format(' '.join(row)))
                 else:  # end of header
                     break
 
@@ -149,8 +149,7 @@ class Mu2Reader(SymbTrReader):
 
         if not int(row[3]) == header['usul']['mertebe']:
             if not header['usul']['mu2_name'] == '[Serbest]':
-                warnings.warn(u'%s: Mertebe and tempo unit are different!'
-                              % symbtr_name)
+                warnings.warn(u'{0!s}: Mertebe and tempo unit are different!'.format(symbtr_name))
                 is_tempo_unit_valid = False
 
         return is_tempo_unit_valid

--- a/symbtrdataextractor/reader/TxtReader.py
+++ b/symbtrdataextractor/reader/TxtReader.py
@@ -141,8 +141,7 @@ class TxtReader(SymbTrReader):
     @staticmethod
     def _validate_index_jump(score_idx, jump_ii, is_index_valid, score_name):
         if score_idx - jump_ii != 1:
-            warnings.warn(u"%s: %s, note index jump."
-                          % (score_name, str(score_idx)))
+            warnings.warn(u"{0!s}: {1!s}, note index jump.".format(score_name, str(score_idx)))
             is_index_valid = False
 
         jump_ii = score_idx  # we assign to the score_idx so the we can warn
@@ -154,7 +153,7 @@ class TxtReader(SymbTrReader):
     def _starts_with_usul_row(score, score_name):
         # check usul row in the start
         if not score['code'][0] == 51:
-            warnings.warn(u'%s Missing the usul row in the start' % score_name)
+            warnings.warn(u'{0!s} Missing the usul row in the start'.format(score_name))
             start_usul_row = False
         else:
             start_usul_row = True
@@ -175,7 +174,6 @@ class TxtReader(SymbTrReader):
 
         if any(v1 != v2 for v1, v2 in zip(val_list, [9, -1, -1, 'Es', 'Es'])):
             is_rest_valid = False
-            warnings.warn(u'%s %s: Invalid Rest'
-                          % (score_name, str(score['index'][ii])))
+            warnings.warn(u'{0!s} {1!s}: Invalid Rest'.format(score_name, str(score['index'][ii])))
 
         return is_rest_valid


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:sertansenturk:symbtrdataextractor?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:sertansenturk:symbtrdataextractor?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
